### PR TITLE
[inv pet] 丸石petの削除

### DIFF
--- a/overrides/config/inventorypets-common.toml
+++ b/overrides/config/inventorypets-common.toml
@@ -234,7 +234,7 @@
 	#Disable the Mishumaa Saba pet (default:false)
 	disableMishumaaSaba = false
 	#Disable the Cobblestone pet (default:false)
-	disableCobblestone = false
+	disableCobblestone = true
 	#Disable the Furnace pet (default:false)
 	disableFurnace = false
 	#Disable the House pet (default:false)


### PR DESCRIPTION
Fix #22 

## やったこと
FTBの保護を貫通するため丸石petの削除

## やらないこと
無し

## できるようになること
ルートテーブルから消える。

## できなくなること
無し

## 動作確認
アイテムとしては消えない。

## その他
